### PR TITLE
Fix trickle output

### DIFF
--- a/etc/tremor/config/example.trickle
+++ b/etc/tremor/config/example.trickle
@@ -1,7 +1,7 @@
 define script validate
 script
   match {"raw": event} of 
-    case  r= %{raw ~= re|(?P<capture>^<134>.*)|} => emit r.raw =>"ok" #testing, that string is syslog with needed facility
+    case  r= %{raw ~= re|(?P<capture>^<134>.*)|} => emit event =>"ok" #testing, that string is syslog with needed facility
     default => emit event => "invalid"
   end
 end;

--- a/etc/tremor/config/example.trickle
+++ b/etc/tremor/config/example.trickle
@@ -1,16 +1,20 @@
 define script validate
 script
   match {"raw": event} of 
-    case  r= %{raw ~= re|(?P<capture>^<134>.*)|} => emit event =>"ok" #testing, that string is syslog with needed facility
-    default => emit event => "invalid"
+    case %{raw ~= glob|<134>*|} =>
+      emit event => "ok" #testing, that string is syslog with needed facility
+    default =>
+      emit event => "invalid"
   end
 end;
 define script parse_audit
 script
   match {"raw": event} of
-    case r = %{raw ~= grok|.* : (?<hostname>[a-zA-Z0-9]+)|} => r.raw 
+    # can do syslog validate (from above) and parse in one step too
+    #case r = %{raw ~= dissect|<134>%{} : %{hostname} %{}|} => r.raw
+    case r = %{raw ~= dissect|%{} : %{hostname} %{}|} => r.raw
     default => emit ["invalid", event] => "invalid"
-end 
+  end
 end;
 create script validate;
 create script parse_audit;


### PR DESCRIPTION
pass the data to `parse_audit` in the expected structure there, for the parsing there to work.

alternative pattern for the fix can be to change `parse_edit` to agree with the output format from the `validate` stage:
```
define script parse_audit
script
  match event of
    case r = %{capture ~= grok|.* : (?<hostname>[a-zA-Z0-9]+)|} => r.capture 
    default => emit ["invalid", event] => "invalid"
end 
end;
```

going with what's in the pr for simplicity

---

also switching to glob/dissect for performance and readability 😄 feel free to adopt the one-liner validate/parse too, if it suits your end needs.

