### PR TITLE
Update dissect to filter out keys from synthetic result fields

### DIFF
--- a/etc/tremor/config/example.trickle
+++ b/etc/tremor/config/example.trickle
@@ -12,7 +12,7 @@ script
   match {"raw": event} of
     # can do syslog validate (from above) and parse in one step too
     #case r = %{raw ~= dissect|<134>%{} : %{hostname} %{}|} => r.raw
-    case r = %{raw ~= dissect|%{} : %{hostname} %{?audisp} %{node} %{type} %{msg}: %{pid} %{uid} %{} %{auid} %{tty} %{} %{ses} %{res} %{pkt_stc}|} => r.raw
+    case r = %{raw ~= dissect|%{} : %{hostname} %{?audisp} node=%{node} type=%{type} msg=%{msg}: pid=%{pid} uid=%{uid} %{} auid=%{auid} tty=%{tty} %{} ses=%{ses} res=%{res} pkt_src_ip="%{pkt_src}"|} => r.raw
     default => emit ["invalid", event] => "invalid"
   end
 end;


### PR DESCRIPTION
To extract the keys as they are present as field names in the synthetic record, simply update dissect accordingly.